### PR TITLE
Add comment section widget

### DIFF
--- a/website/templates/website/event.html
+++ b/website/templates/website/event.html
@@ -9,5 +9,24 @@
     <h1 class="title">{{ event.name }}</h1>
   </div>
   <p>{{ content.main }}</p>
+
+  <!-- comment section -->
+  <div id="wpac-comment"></div>
+  <script type="text/javascript">
+  wpac_init = window.wpac_init || [];
+  wpac_init.push({widget: 'Comment', id: 25587});
+  (function() {
+      if ('WIDGETPACK_LOADED' in window) return;
+      WIDGETPACK_LOADED = true;
+      var mc = document.createElement('script');
+      mc.type = 'text/javascript';
+      mc.async = true;
+      mc.src = 'https://embed.widgetpack.com/widget.js';
+      var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(mc, s.nextSibling);
+  })();
+  </script>
+  <br>
+  <br>
 </div>
+
 {% endblock %}


### PR DESCRIPTION
As discussed, we've decided to go w a third-party comment section, mainly because: 
* guarantees that it will work well - functionality and ui support (like for mobile) 
* time constraints and uni lol 

website: https://widgetpack.com/
login details are found on confluence 
* you can sign in and adjust the settings (if people can edit/delete their comments, what social media they can use to sign in, etc) 
* You can also do comment moderation on there as well 
++ lots more 

The comments that it displays on each page is dependent on the url - so long as the url is unique, it will know to only display comments for that particular page and they won't get all muddled up. 